### PR TITLE
Restrict plugin by post type

### DIFF
--- a/includes/admin/class-wc-search-orders-by-product-admin.php
+++ b/includes/admin/class-wc-search-orders-by-product-admin.php
@@ -51,6 +51,18 @@ class WC_Search_Orders_By_Product_Admin {
 	}
 
 	/**
+	 * Restrict dropdown on WooCommerce Order post type
+	 *
+	 */
+	private function is_active_on_post_type() {
+		global $typenow;
+
+		$access = in_array( $typenow, wc_get_order_types( 'order-meta-boxes' ), true );
+
+		return apply_filters('sobp_restrict_by_post_type', $access, $typenow);
+	}
+
+	/**
 	 * Admin Scripts
 	 */
 	public function sobp_enqueue_admin_scripts_styles() {
@@ -87,9 +99,7 @@ class WC_Search_Orders_By_Product_Admin {
 	 * Product search dropdown restriction
 	 */
 	public function sobp_display_products_search_dropdown_restrict() {
-		global $typenow;
-
-		if ( in_array( $typenow, wc_get_order_types( 'order-meta-boxes' ) ) ) {
+		if ( $this->is_active_on_post_type() ) {
 			$this->display_products_search_dropdown();
 		}
 	}
@@ -260,9 +270,9 @@ class WC_Search_Orders_By_Product_Admin {
 	 * Filter orders as per request
 	 */
 	public function sobp_filter_orders_request_by_product($where) {
-	    global $wpdb,$typenow;
+	    global $wpdb;
         
-        if ( in_array( $typenow, wc_get_order_types( 'order-meta-boxes' ), true ) ) {
+        if ( $this->is_active_on_post_type() ) {
             if( is_search() ) {
                 // Search orders by product
                 if(!empty( $_GET['product_id'] ) && empty($_GET['search_product_type']) && empty($_GET['search_product_cat'])) {

--- a/includes/admin/class-wc-search-orders-by-product-admin.php
+++ b/includes/admin/class-wc-search-orders-by-product-admin.php
@@ -59,6 +59,11 @@ class WC_Search_Orders_By_Product_Admin {
 
 		$access = in_array( $typenow, wc_get_order_types( 'order-meta-boxes' ), true );
 
+		// WooCommerce Subscription compatibility
+		if ($typenow === 'shop_subscription') {
+		  $access = false;
+    }
+
 		return apply_filters('sobp_restrict_by_post_type', $access, $typenow);
 	}
 


### PR DESCRIPTION
As reported by another person [here](https://wordpress.org/support/topic/causes-subscription-crash/), the plugin does not work with [WooCommerce Subscription](https://woocommerce.com/products/woocommerce-subscriptions/).

## Incompatibility explained

The "Subscription" page of the WooCommerce Subscription plugin never shows the subscriptions orders because WC Search Orders By Product only search on post type `order` but the subscription are registered with another post type but still comes up when calling `wc_get_order_types( 'order-meta-boxes' )` which is how WC Search Orders By Product checks if it should be active.


## Solution

So I added a filter named `sobp_restrict_by_post_type` that allow user to restrict the plugin to certain post type. I also already restricted the plugin if the post type is `shop_subscription` so it immediately works with WooCommerce Subscription.


## Sidenote

I worked on the 1.4 branch but the latest version is 1.5, I couldn't found the latest version on Github.